### PR TITLE
 UPDATE for add_attachment with bugzilla.

### DIFF
--- a/docs/bugzilla.md
+++ b/docs/bugzilla.md
@@ -109,7 +109,7 @@ users.
 t.add_cc(['username1@mail.com', 'username2@mail.com'])
 ```
 
-### add_attachment(self, data, file_name, summary, \*\*kwargs ) <a name="add_attachment"></a>
+### add_attachment(self, file_name, data, summary, \*\*kwargs ) <a name="add_attachment"></a>
 
 Add attachment in a Bugzilla ticket. Keyword arguments are used to specify
 additional attachment options.

--- a/docs/bugzilla.md
+++ b/docs/bugzilla.md
@@ -111,11 +111,11 @@ t.add_cc(['username1@mail.com', 'username2@mail.com'])
 
 ### add_attachment(self, data, file_name, summary, \*\*kwargs ) <a name="add_attachment"></a>
 
-Add attachment in a Bugzilla ticket. Keyword arguments are used to 
-specify ticket fields if any.
+Add attachment in a Bugzilla ticket. Keyword arguments are used to specify
+additional attachment options.
 
 ```python
-t.add_attachment(file_name='e Name to be displayed on UI',
+t.add_attachment(file_name='Name to be displayed on UI',
                  data='Location(path) or contents of the attachment',
                  summary='A short string describing the attachment.')
 ```

--- a/docs/bugzilla.md
+++ b/docs/bugzilla.md
@@ -19,6 +19,7 @@ http://bugzilla.readthedocs.io/en/latest/api/index.html
 - [change_status()](#status)
 - [remove_cc()](#remove_cc)
 - [add_cc()](#add_cc)
+- [add_attachment()](#add_attachment)
 
 ### create(self, summary, description, \*\*kwargs) <a name="create"></a>
 
@@ -107,3 +108,16 @@ users.
 ```python
 t.add_cc(['username1@mail.com', 'username2@mail.com'])
 ```
+
+### add_attachment(self, data, file_name, summary, \*\*kwargs ) <a name="add_attachment"></a>
+
+Add attachment in a Bugzilla ticket. Keyword arguments are used to 
+specify ticket fields if any.
+
+```python
+t.add_attachment(file_name='e Name to be displayed on UI',
+                 data='Location(path) or contents of the attachment',
+                 summary='A short string describing the attachment.')
+```
+
+

--- a/examples/bugzilla_examples.md
+++ b/examples/bugzilla_examples.md
@@ -88,6 +88,9 @@ t = BugzillaTicket(<bugzilla_url>,
 t.add_comment('Test Comment')
 t.edit(priority='low',
        severity='low')
+t.add_attchment(file_name='test_attachment.patch',
+                data=<contents/file-location>,
+                summary=<summary describing attachment>)
        
 # Work with a different ticket.
 t.set_ticket_id(<new_ticket_id>)

--- a/ticketutil/bugzilla.py
+++ b/ticketutil/bugzilla.py
@@ -264,10 +264,10 @@ class BugzillaTicket(ticket.Ticket):
             r = self.s.post("{0}/{1}/attachment".format(self.rest_url, self.ticket_id), json=params, headers=headers)
             r.raise_for_status()
             if 'message' in r.json():
-                logging.error("Change status error message: {0}".format(r.json()['message']))
+                logging.error("Add attachment: {0}".format(r.json()['message']))
                 return
-            logging.debug("Adding attachment for the ticket: Status Code: {0}".format(r.status_code))
-            logging.info("Added a new attachment for: {0} - {1}".format(self.ticket_id, self.ticket_url))
+            logging.debug("Adding attachment to ticket: Status Code: {0}".format(r.status_code))
+            logging.info("Added a new attachment to: {0} - {1}".format(self.ticket_id, self.ticket_url))
         except requests.RequestException as e:
             logging.error("Error changing status of ticket")
             logging.error(e.args[0])

--- a/ticketutil/bugzilla.py
+++ b/ticketutil/bugzilla.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 
 import requests
@@ -229,6 +230,41 @@ class BugzillaTicket(ticket.Ticket):
             logging.info("Added comment to ticket {0} - {1}".format(self.ticket_id, self.ticket_url))
         except requests.RequestException as e:
             logging.error("Error adding comment to ticket")
+            logging.error(e.args[0])
+
+    def add_attachment(self, data, **kwargs):
+        """
+        :param status: Status to change to.
+        :return:
+        """
+        if not self.ticket_id:
+            logging.error("No ticket ID associated with ticket object. Set ticket ID with set_ticket_id(ticket_id)")
+            return
+
+        f = open(data, "+rb")
+        file_name = f.read()
+
+        content = kwargs['content_type']
+        if content == "image/png":
+            data = base64.standard_b64encode(file_name).decode('utf-8')
+        else:
+            data = base64.standard_b64encode(file_name).decode('ascii')
+
+        params = {"data": data}
+        params.update(kwargs)
+
+        # Attempt to change status of ticket.
+        try:
+            headers = {"Content-Type": "application/json"}
+            r = self.s.post("{0}/{1}/attachment".format(self.rest_url, self.ticket_id), json=params, headers=headers)
+            r.raise_for_status()
+            if 'message' in r.json():
+                logging.error("Change status error message: {0}".format(r.json()['message']))
+                return
+            logging.debug("Changing status of ticket: Status Code: {0}".format(r.status_code))
+            logging.info("Changed status of ticket {0} - {1}".format(self.ticket_id, self.ticket_url))
+        except requests.RequestException as e:
+            logging.error("Error changing status of ticket")
             logging.error(e.args[0])
 
     def change_status(self, status, **kwargs):

--- a/ticketutil/bugzilla.py
+++ b/ticketutil/bugzilla.py
@@ -269,7 +269,7 @@ class BugzillaTicket(ticket.Ticket):
             logging.debug("Adding attachment to ticket: Status Code: {0}".format(r.status_code))
             logging.info("Added a new attachment to: {0} - {1}".format(self.ticket_id, self.ticket_url))
         except requests.RequestException as e:
-            logging.error("Error changing status of ticket")
+            logging.error("Error adding attachment to ticket")
             logging.error(e.args[0])
 
     def change_status(self, status, **kwargs):


### PR DESCRIPTION
 - Added new functionality for add_attachment with bugzilla.
 -  add_attachment() has also been given a **kwargs option, allowing the user to specify ticket options.
 - Modified docs/bugzilla.md to include add_attachment.
 - Modified /examples/bugzilla_examples.md to include add_attachment.

