### PR TITLE
Remove unused part of code in jira.py

### DIFF
--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -41,9 +41,6 @@ class JiraTicket(ticket.Ticket):
 
         # If we are receiving a ticket_id, it indicates we'll be doing an update or resolve, so set ticket_url.
         if self.ticket_id:
-            if '-' not in self.ticket_id:
-                # Adding the project to the beginning of the ticket_id, so that the ticket_id is of the form KEY-XX.
-                self.ticket_id = "{0}-{1}".format(self.project, self.ticket_id)
             ticket_url = "{0}/browse/{1}".format(self.url, self.ticket_id)
 
         # This method is called from set_ticket_id(), _create_ticket_request(), or Ticket.__init__().


### PR DESCRIPTION
I believe this part of code is never used. If the ticket_id = '2144' instead of 'DEVOPSA-2144', the error in _verify_ticket_id in ticket.py terminates the process and the method _generate_ticket_url is not used