### PR TITLE
Unify verify ticket

### DIFF
--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -204,23 +204,6 @@ class TestBugzillaTicket(TestCase):
             ticket = bugzilla.BugzillaTicket(URL, PROJECT, TICKET_ID)
             self.assertEquals(ticket.get_ticket_content(), FAILURE_RESULT._replace(error_message=error_message))
 
-    @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
-    @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')
-    def test_verify_ticket_success(self, mock_session, mock_content):
-        mock_session.return_value = FakeSession()
-        mock_content.return_value = SUCCESS_RESULT
-        ticket = bugzilla.BugzillaTicket(URL, PROJECT, TICKET_ID)
-        self.assertTrue(ticket._verify_ticket_id(TICKET_ID))
-
-    @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
-    @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')
-    def test_verify_ticket_failure(self, mock_session, mock_content):
-        mock_session.return_value = FakeSession(status_code=400)
-        mock_content.return_value = FAILURE_RESULT
-        with self.assertRaises(ticketutil.ticket.TicketException):
-            ticket = bugzilla.BugzillaTicket(URL, PROJECT, TICKET_ID)
-            self.assertFalse(ticket._verify_ticket_id(TICKET_ID))
-
     @patch.object(bugzilla.BugzillaTicket, '_create_ticket_request')
     @patch.object(bugzilla.BugzillaTicket, '_create_ticket_parameters')
     @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')

--- a/tests/test_bugzilla.py
+++ b/tests/test_bugzilla.py
@@ -103,7 +103,7 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession()
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         self.assertEqual(TICKET_URL, ticket._generate_ticket_url())
-        self.assertEqual(ticket.request_result, SUCCESS_RESULT._replace(url=TICKET_URL, ticket_content=MOCK200))
+        self.assertEqual(ticket.request_result, SUCCESS_RESULT._replace(url=TICKET_URL))
 
     @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')
     def test_generate_ticket_url_no_ticket_id(self, mock_session):
@@ -315,7 +315,7 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession(status_code=402)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.edit()
-        self.assertEqual(t, SUCCESS_RESULT._replace(url=TICKET_URL, ticket_content=MOCK402))
+        self.assertEqual(t, SUCCESS_RESULT._replace(url=TICKET_URL))
 
     @patch.object(bugzilla, '_prepare_ticket_fields')
     @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')
@@ -323,7 +323,7 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession(status_code=401)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.edit()
-        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, MOCK401))
+        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, None))
 
     @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
     @patch.object(bugzilla, '_prepare_ticket_fields')
@@ -356,7 +356,7 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession(status_code=401)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.add_comment('')
-        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, MOCK401))
+        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, None))
 
     @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
     @patch.object(bugzilla, '_prepare_ticket_fields')
@@ -379,7 +379,7 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession()
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.add_attachment('file_name', 'data', 'summary')
-        self.assertEqual(t, RETURN_RESULT('Failure', 'File file_name not found', TICKET_URL, MOCK200))
+        self.assertEqual(t, RETURN_RESULT('Failure', 'File file_name not found', TICKET_URL, None))
 
     @patch('ticketutil.bugzilla.base64.standard_b64encode')
     @patch('ticketutil.bugzilla.mimetypes.guess_type')
@@ -402,7 +402,7 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession(status_code=401)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.add_attachment('file_name', 'data', 'summary')
-        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, MOCK401))
+        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, None))
 
     @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
     @patch('ticketutil.bugzilla.base64.standard_b64encode')
@@ -437,7 +437,7 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession(status_code=401)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.change_status('')
-        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, MOCK401))
+        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, None))
 
     @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
     @patch.object(bugzilla, '_prepare_ticket_fields')
@@ -469,14 +469,14 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession(status_code=402)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.add_cc('')
-        self.assertEqual(t, SUCCESS_RESULT._replace(url=TICKET_URL, ticket_content=MOCK402))
+        self.assertEqual(t, SUCCESS_RESULT._replace(url=TICKET_URL))
 
     @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')
     def test_add_cc_error(self, mock_session):
         mock_session.return_value = FakeSession(status_code=401)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.add_cc('')
-        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, MOCK401))
+        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, None))
 
     @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
     @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')
@@ -507,14 +507,14 @@ class TestBugzillaTicket(TestCase):
         mock_session.return_value = FakeSession(status_code=402)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.remove_cc('')
-        self.assertEqual(t, SUCCESS_RESULT._replace(url=TICKET_URL, ticket_content=MOCK402))
+        self.assertEqual(t, SUCCESS_RESULT._replace(url=TICKET_URL))
 
     @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')
     def test_remove_cc_error(self, mock_session):
         mock_session.return_value = FakeSession(status_code=401)
         ticket = bugzilla.BugzillaTicket(URL, PROJECT, ticket_id=TICKET_ID)
         t = ticket.remove_cc('')
-        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, MOCK401))
+        self.assertEqual(t, RETURN_RESULT('Failure', 'There is some error.', TICKET_URL, None))
 
     @patch.object(bugzilla.BugzillaTicket, 'get_ticket_content')
     @patch.object(bugzilla.BugzillaTicket, '_create_requests_session')

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -155,23 +155,6 @@ class TestJiraTicket(TestCase):
             t = ticket._verify_ticket_id(ticket_id=TICKET_ID)
             self.assertEqual(t, FAILURE_RESULT._replace(error_message=error_message))
 
-    @patch.object(jira.JiraTicket, 'get_ticket_content')
-    @patch.object(jira.JiraTicket, '_create_requests_session')
-    def test_verify_ticket_id_success(self, mock_session, mock_content):
-        mock_session.return_value = FakeSession()
-        mock_content.return_value = SUCCESS_RESULT
-        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
-        self.assertTrue(ticket._verify_ticket_id(ticket_id=TICKET_ID))
-
-    @patch.object(jira.JiraTicket, 'get_ticket_content')
-    @patch.object(jira.JiraTicket, '_create_requests_session')
-    def test_verify_ticket_id_failure(self, mock_session, mock_content):
-        mock_session.return_value = FakeSession()
-        mock_content.return_value = FAILURE_RESULT
-        with self.assertRaises(TicketException):
-            ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
-            self.assertFalse(ticket._verify_ticket_id(ticket_id=TICKET_ID))
-
     @patch.object(jira.JiraTicket, '_create_ticket_parameters')
     @patch.object(jira.JiraTicket, '_create_ticket_request')
     @patch.object(jira.JiraTicket, '_create_requests_session')

--- a/tests/test_redmine.py
+++ b/tests/test_redmine.py
@@ -125,19 +125,6 @@ class TestRedmineTicket(TestCase):
         t = ticket.get_ticket_content(ticket_id=TICKET_ID)
         self.assertEqual(t.ticket_content, MOCK_CONTENT)
 
-    @patch.object(redmine.RedmineTicket, '_create_requests_session')
-    def test_verify_ticket_id(self, mock_session):
-        mock_session.return_value = FakeSession()
-        ticket = redmine.RedmineTicket(URL, PROJECT)
-        self.assertTrue(ticket._verify_ticket_id(PROJECT))
-
-    @patch.object(redmine.RedmineTicket, '_create_requests_session')
-    def test_verify_ticket_id_valid(self, mock_session):
-        mock_session.return_value = FakeSession(status_code=400)
-        with patch.object(redmine.RedmineTicket, '_verify_project'):
-            ticket = redmine.RedmineTicket(URL, PROJECT)
-        self.assertFalse(ticket._verify_ticket_id(PROJECT))
-
     @patch.object(redmine.RedmineTicket, '_create_ticket_request')
     @patch.object(redmine.RedmineTicket, '_create_ticket_parameters')
     @patch.object(redmine.RedmineTicket, '_create_requests_session')

--- a/tests/test_ticket.py
+++ b/tests/test_ticket.py
@@ -65,6 +65,12 @@ class ChildTicket(ticket.Ticket):
     def _verify_project(self, project):
         return True
 
+    def get_ticket_content(ticket_id):
+        if 'PROJECT-00' in ticket_id:
+            return {'status': 'Success'}
+        else:
+            return {'status': 'Failure'}
+
     def _verify_ticket_id(self, ticket_id):
         if 'PROJECT-00' in ticket_id:
             return True
@@ -85,6 +91,18 @@ class FakeCredentials(object):
 
 
 class TestTicket(TestCase):
+
+    @patch.object(ticket.Ticket, '_create_requests_session')
+    def test_verify_ticket_id(self, mock_session):
+        mock_session.return_value = FakeSession()
+        t = ChildTicket(PROJECT, TICKET_ID)
+        self.assertTrue(t._verify_ticket_id(TICKET_ID))
+
+    @patch.object(ticket.Ticket, '_create_requests_session')
+    def test_verify_ticket_id_non_valid(self, mock_session):
+        mock_session.return_value = FakeSession()
+        t = ChildTicket(PROJECT, TICKET_ID)
+        self.assertFalse(t._verify_ticket_id('PROJECT-010'))
 
     @patch.object(ticket.Ticket, '_create_requests_session')
     def test_set_ticket_id(self, mock_session):

--- a/ticketutil/bugzilla.py
+++ b/ticketutil/bugzilla.py
@@ -140,20 +140,6 @@ class BugzillaTicket(ticket.Ticket):
             logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)
 
-    def _verify_ticket_id(self, ticket_id):
-        """
-        Check if ticket_id is connected with valid ticket for the given Bugzilla instance.
-        :param ticket_id: The ticket you're verifying.
-        :return: True or False depending on if ticket is valid.
-        """
-        self.request_result = self.get_ticket_content(ticket_id)
-        if 'Failure' in self.request_result.status:
-            logger.error("Ticket {0} is not valid".format(ticket_id))
-            return False
-        else:
-            logger.debug("Ticket {0} is valid".format(ticket_id))
-            return True
-
     def create(self, summary, description, component, version, **kwargs):
         """
         Creates a ticket.

--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -104,20 +104,6 @@ class JiraTicket(ticket.Ticket):
                 logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)
 
-    def _verify_ticket_id(self, ticket_id):
-        """
-        Check if ticket_id is connected with valid ticket for the given JIRA instance.
-        :param ticket_id: The ticket you're verifying.
-        :return: True or False depending on if ticket is valid.
-        """
-        result = self.get_ticket_content(ticket_id)
-        if 'Failure' in result.status:
-            logger.error("Ticket {0} is not valid".format(ticket_id))
-            return False
-        logger.debug("Ticket {0} is valid".format(ticket_id))
-        self.ticket_id = ticket_id
-        return True
-
     def create(self, summary, description, type, **kwargs):
         """
         Creates a ticket.

--- a/ticketutil/redmine.py
+++ b/ticketutil/redmine.py
@@ -78,7 +78,7 @@ class RedmineTicket(ticket.Ticket):
                 logger.error(error_message)
                 return self.request_result._replace(status='Failure', error_message=error_message)
         try:
-            r = self.s.get("{0}/{1}.json?include=attachments,journals,watchers,children,relations,changesets" \
+            r = self.s.get("{0}/{1}.json?include=attachments,journals,watchers,children,relations,changesets"
                            "".format(self.rest_url, ticket_id))
             logger.debug("Get ticket content: status code: {0}".format(r.status_code))
             r.raise_for_status()
@@ -89,20 +89,6 @@ class RedmineTicket(ticket.Ticket):
             logger.error(error_message)
             logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)
-
-    def _verify_ticket_id(self, ticket_id):
-        """
-        Check if ticket_id is connected with valid ticket for the given Redmine instance.
-        :param ticket_id: The ticket you're verifying.
-        :return: True or False depending on if ticket is valid.
-        """
-        result = self.get_ticket_content(ticket_id)
-        if 'Failure' in result.status:
-            logger.error("Ticket {0} is not valid".format(ticket_id))
-            return False
-        logger.debug("Ticket {0} is valid".format(ticket_id))
-        self.ticket_id = ticket_id
-        return True
 
     def create(self, subject, description, **kwargs):
         """

--- a/ticketutil/ticket.py
+++ b/ticketutil/ticket.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from collections import namedtuple
 
 import gssapi
@@ -46,6 +45,20 @@ class Ticket(object):
                 raise TicketException("Ticket {0} is not valid".format(self.ticket_id))
             else:
                 self.ticket_url = self._generate_ticket_url()
+
+    def _verify_ticket_id(self, ticket_id):
+        """
+        Check if ticket_id is connected with valid ticket for the given ticketing tool instance.
+        :param ticket_id: The ticket you're verifying.
+        :return: True or False depending on if ticket is valid.
+        """
+        result = self.get_ticket_content(ticket_id)
+        if 'Failure' in result.status:
+            logger.error("Ticket {0} is not valid".format(ticket_id))
+            return False
+        logger.debug("Ticket {0} is valid".format(ticket_id))
+        self.ticket_id = ticket_id
+        return True
 
     def set_ticket_id(self, ticket_id):
         """


### PR DESCRIPTION
Almost every ToolNameTicket uses the identical verify_ticket_id() method. So I moved it into a parent Ticket class. There are also some minor style changes.