### PR TITLE
Add get_ticket_content() method for RTTicket

### DIFF
--- a/read-the-docs/source/Usage.rst
+++ b/read-the-docs/source/Usage.rst
@@ -100,6 +100,7 @@ URL of the ticket. An example is below.
 
 .. note::
 
-    For ServiceNow, Jira, Bugzilla and Redmine the user-accessible methods return a ``ticket_content``
-    field, which contains a json representation of the current ticket's content.
+    For all ticketing tools the user-accessible methods return a ``ticket_content``
+    field, which contains a json representation of the current ticket's content with
+    exception of RT returning list of strings.
     Access this data with ``t.ticket_content``.

--- a/read-the-docs/source/Usage.rst
+++ b/read-the-docs/source/Usage.rst
@@ -101,6 +101,5 @@ URL of the ticket. An example is below.
 .. note::
 
     For all ticketing tools the user-accessible methods return a ``ticket_content``
-    field, which contains a json representation of the current ticket's content with
-    exception of RT returning list of strings.
+    field, which contains a json representation of the current ticket's content.
     Access this data with ``t.ticket_content``.

--- a/read-the-docs/source/rt.rst
+++ b/read-the-docs/source/rt.rst
@@ -16,11 +16,30 @@ https://rt-wiki.bestpractical.com/wiki/REST
 Methods
 ^^^^^^^
 
+-  `get_ticket_content() <#get_ticket_content>`__
 -  `create() <#create>`__
 -  `edit() <#edit>`__
 -  `add_comment() <#comment>`__
 -  `change_status() <#status>`__
 -  `add_attachment() <#add_attachment>`__
+
+
+get_ticket_content()
+--------------------
+
+``get_ticket_content(self, ticket_id=None, option='show')``
+
+Queries the RT API to get the ticket_content using ticket_id. The
+ticket_content is expressed as a list of strings representing lines
+in text returned by specific call. Calls have different options ('show',
+'comment', 'attachments', 'history') in dependence of what kind of
+content is required. The API calling is described in
+https://rt-wiki.bestpractical.com/wiki/REST#Ticket
+
+.. code:: python
+
+    t = ticket.get_ticket_content(<ticket_id>, option='attachments')
+    returned_ticket_content = t.ticket_content
 
 
 create()
@@ -211,10 +230,13 @@ Update existing RT tickets
     t = ticket.edit(priority='4',
                     cc='username@mail.com')
 
+    # Check the ticket content.
+    t = ticket.get_ticket_id()
+    returned_ticket_content = t.ticket_content
+
     # Work with a different ticket.
     t = ticket.set_ticket_id(<new_ticket_id>)
     t = ticket.change_status('Resolved')
 
     # Close Requests session.
     ticket.close_requests_session()
-

--- a/read-the-docs/source/rt.rst
+++ b/read-the-docs/source/rt.rst
@@ -29,11 +29,12 @@ get_ticket_content()
 
 ``get_ticket_content(self, ticket_id=None, option='show')``
 
-Queries the RT API to get the ticket_content using ticket_id. The
-ticket_content is expressed as a list of strings representing lines
-in text returned by specific call. Calls have different options ('show',
-'comment', 'attachments', 'history') in dependence of what kind of
-content is required. The API calling is described in
+Queries the RT API to get the ticket_content using ticket_id. Calls
+have different options ('show', 'comment', 'attachments', 'history')
+in dependence of what kind of content is required. The ticket_content
+is expressed as a dictionary for options 'show', 'attachments' and
+'history' and as a list of strings representing lines in returned text
+for option 'comment'. The API calling is described in
 https://rt-wiki.bestpractical.com/wiki/REST#Ticket
 
 .. code:: python

--- a/ticketutil/rt.py
+++ b/ticketutil/rt.py
@@ -101,30 +101,42 @@ class RTTicket(ticket.Ticket):
             logger.debug("Project {0} is valid".format(project))
             return True
 
-    def _verify_ticket_id(self, ticket_id):
+    def get_ticket_content(self, ticket_id=None, option='show'):
         """
-        Queries the RT API to see if ticket_id is a valid ticket for the given RT instance.
-        :param ticket_id: The ticket you're verifying.
-        :return: True or False depending on if ticket is valid.
+        Queries the Redmine API to get the ticket_content using ticket_id.
+        :param ticket_id: ticket number, if not set self.ticket_id is used.
+        :param option: specifies the type of content with possible values 'show', 'attachments', 'comment' and
+                       'history'
+        :return: self.request_result: Named tuple containing request status, error_message, url info and
+                 ticket_content.
         """
+        if ticket_id is None:
+            ticket_id = self.ticket_id
+            if not self.ticket_id:
+                error_message = "No ticket ID associated with ticket object. " \
+                                "Set ticket ID with set_ticket_id(<ticket_id>)"
+                logger.error(error_message)
+                return self.request_result._replace(status='Failure', error_message=error_message)
         try:
-            r = self.s.get("{0}/ticket/{1}/show".format(self.rest_url, ticket_id))
-            logger.debug("Verify ticket_id: status code: {0}".format(r.status_code))
+            r = self.s.get("{0}/ticket/{1}/{2}".format(self.rest_url, ticket_id, option))
+            logger.debug("Get ticket content: status code: {0}".format(r.status_code))
             r.raise_for_status()
         except requests.RequestException as e:
-            logger.error("Unexpected error occurred when verifying ticket_id")
+            error_message = "Error getting ticket content"
+            logger.error(error_message)
             logger.error(e)
-            return False
+            return self.request_result._replace(status='Failure', error_message=error_message)
 
         # RT's API returns 200 even if the ticket is not valid. We need to parse the response.
         error_responses = ["Ticket {0} does not exist.".format(ticket_id),
                            "Bad Request"]
         if any(error in r.text for error in error_responses):
-            logger.error("Ticket {0} is not valid".format(ticket_id))
-            return False
-        else:
-            logger.debug("Ticket {0} is valid".format(ticket_id))
-            return True
+            error_message = "Ticket {0} is not valid".format(ticket_id)
+            logger.error(error_message)
+            return self.request_result._replace(status='Failure', error_message=error_message)
+
+        self.ticket_content = r.text.split('\n')
+        return self.request_result._replace(ticket_content=self.ticket_content)
 
     def create(self, subject, text, **kwargs):
         """
@@ -216,6 +228,7 @@ class RTTicket(ticket.Ticket):
         self.ticket_id = re.search('Ticket (\d+) created', ticket_content).groups()[0]
         self.ticket_url = self._generate_ticket_url()
         logger.info("Created ticket {0} - {1}".format(self.ticket_id, self.ticket_url))
+        self.request_result = self.get_ticket_content()
         return self.request_result
 
     def edit(self, **kwargs):
@@ -263,6 +276,7 @@ class RTTicket(ticket.Ticket):
             logger.error(error_message)
             return self.request_result._replace(status='Failure', error_message=error_message)
         logger.info("Edited ticket {0} - {1}".format(self.ticket_id, self.ticket_url))
+        self.request_result = self.get_ticket_content()
         return self.request_result
 
     def add_comment(self, comment):
@@ -300,6 +314,7 @@ class RTTicket(ticket.Ticket):
             logger.error(error_message)
             return self.request_result._replace(status='Failure', error_message=error_message)
         logger.info("Added comment to ticket {0} - {1}".format(self.ticket_id, self.ticket_url))
+        self.request_result = self.get_ticket_content(option='comment')
         return self.request_result
 
     def change_status(self, status):
@@ -333,6 +348,7 @@ class RTTicket(ticket.Ticket):
             logger.error(error_message)
             return self.request_result._replace(status='Failure', error_message=error_message)
         logger.info("Changed status of ticket {0} - {1}".format(self.ticket_id, self.ticket_url))
+        self.request_result = self.get_ticket_content()
         return self.request_result
 
     def add_attachment(self, file_name):
@@ -373,6 +389,7 @@ class RTTicket(ticket.Ticket):
             logger.error(error_message)
             return self.request_result._replace(status='Failure', error_message=error_message)
         logger.info("Attached file {0} to ticket {1} - {2}".format(file_name, self.ticket_id, self.ticket_url))
+        self.request_result = self.get_ticket_content(option='attachments')
         return self.request_result
 
 

--- a/ticketutil/rt.py
+++ b/ticketutil/rt.py
@@ -410,7 +410,7 @@ def _convert_string(text):
     """
     Converts string into more appropriate form for reading and accessing.
     :param text: Text to be converted in a form of string.
-    :return: List of stings or a dictionary in dependance of which form is preferable.
+    :return: List of strings or a dictionary in dependance of which form is preferable.
     """
     lines = text.split('\n')
     if 'Stack' in text:


### PR DESCRIPTION
The get_ticket_content() method for RTTicket was added, tests and documentation were adjusted accordingly. The method itself was tested with all options (show, comment, history, attachments) and it returns expected results. However methods which use get_ticket_content() to alternate ticket_content attribute, namely _create_ticket_request(), edit(), add_comment(), change_status() and add_attachment() were not tested. The reason is that I don't have required authorization to create and manage tickets at https://engineering.redhat.com/rt/ and don't know about any testing instance for RT. I don't find it strictly necessary to test all those methods, as they only use get_ticket_content() which works and was tested.
Following points are to be discussed:

- The result of API call is returned in a form of raw text string, not a json dictionary as it was for other tools. I found it most effective to transform this raw string into list of strings representing lines: self.ticket_content = r.text.split('\n')
Possible alternative forms can be a subject for discussion.
- Do we want different kinds of ticket content to be returned? Methods create(), edit() and change_status() return basic ticket content defined by 'show' option, whereas add_attachment() returns just attachment info and add_comment() just comment info and passes that to ticket_content attribute. Another alternative would be to always fill the ticket_content list with results from all options combined.