### PR TITLE
Fix error handling when adding comments to Jira

### DIFF
--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -185,7 +185,7 @@ class JiraTicket(ticket.Ticket):
             logger.debug("Create ticket: status code: {0}".format(r.status_code))
             r.raise_for_status()
         except requests.RequestException as e:
-            error_message = "Error creating ticket - {0}".format(list(r.json()['errors'].values())[0])
+            error_message = "Error creating ticket - {0}".format(_extract_error_messages(r.json()))
             logger.error(error_message)
             logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)
@@ -236,7 +236,7 @@ class JiraTicket(ticket.Ticket):
             self.request_result = self.get_ticket_content()
             return self.request_result
         except requests.RequestException as e:
-            error_message = "Error editing ticket - {0}".format(list(r.json()['errors'].values())[0])
+            error_message = "Error editing ticket - {0}".format(_extract_error_messages(r.json()))
             logger.error(error_message)
             logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)
@@ -264,7 +264,7 @@ class JiraTicket(ticket.Ticket):
             self.request_result = self.get_ticket_content()
             return self.request_result
         except requests.RequestException as e:
-            error_message = "Error adding comment to ticket - {0}".format(list(r.json()['errors'].values())[0])
+            error_message = "Error adding comment to ticket - {0}".format(_extract_error_messages(r.json()))
             logger.error(error_message)
             logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)
@@ -510,6 +510,14 @@ def _prepare_ticket_fields(fields):
                 fields.pop('type')
 
         return fields
+
+
+def _extract_error_messages(data):
+    if data.get('errorMessages'):
+        return ' '.join(data['errorMessages'])
+    elif data.get('errors'):
+        return ' '.join(data['errors'].values())
+    return ''
 
 
 def main():


### PR DESCRIPTION
In some cases Jira returns error messages in "errorMessages" and field "errors" is empty...

```json
{
  "errorMessages": [
    "You do not have the permission to comment on this issue."
  ],
  "errors": {}
}
```

which caused IndexError...

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/ticketutil/jira.py", line 240, in add_comment
    r.raise_for_status()
  File "/usr/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error:  for url: https://xyz

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./jira_auto.py", line 620, in <module>
    collected_data[issue['key']] = process_task(issue)
  File "./jira_auto.py", line 155, in process_task
    check_modules(subissue, issue, data)
  File "./jira_auto.py", line 246, in check_modules
    jira.add_comment('Module does not exist yet')
  File "/usr/local/lib/python3.6/site-packages/ticketutil/jira.py", line 244, in add_comment
    error_message = "Error adding comment to ticket - {0}".format(list(r.json()['errors'].values())[0])
IndexError: list index out of range
```