### PR TITLE
Fix RuntimeError in Python 3.8

### DIFF
--- a/ticketutil/bugzilla.py
+++ b/ticketutil/bugzilla.py
@@ -506,7 +506,7 @@ def _prepare_ticket_fields(operation, fields):
                 fields["groups"] = [fields["groups"]]
             fields["groups"] = {"add": fields["groups"]}
 
-    for key, value in fields.items():
+    for key, value in list(fields.items()):
         if key == 'assignee':
             fields['assigned_to'] = value
             fields.pop('assignee')

--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -496,7 +496,7 @@ def _prepare_ticket_fields(fields):
         if 'type' in fields and fields['type'] == 'Sub-task' and 'parent' not in fields:
             raise KeyError("Parent field is required while creating a Sub Task")
 
-        for key, value in fields.items():
+        for key, value in list(fields.items()):
             if key in ['priority', 'assignee', 'reporter']:
                 fields[key] = {'name': value}
             if key in ['parent']:

--- a/ticketutil/redmine.py
+++ b/ticketutil/redmine.py
@@ -501,7 +501,7 @@ class RedmineTicket(ticket.Ticket):
         :param fields: Ticket fields.
         :return: fields: Ticket fields in the correct form for the ticketing tool.
         """
-        for key, value in fields.items():
+        for key, value in list(fields.items()):
             if key == 'priority':
                 fields['priority_id'] = self._get_priority_id(value)
                 fields.pop('priority')

--- a/ticketutil/rt.py
+++ b/ticketutil/rt.py
@@ -399,7 +399,7 @@ def _prepare_ticket_fields(fields):
         :param fields: Ticket fields.
         :return: fields: Ticket fields in the correct form for the ticketing tool.
         """
-        for key, value in fields.items():
+        for key, value in list(fields.items()):
             if key in ['cc', 'admincc']:
                 if isinstance(value, list):
                     fields[key] = ', '.join(value)

--- a/ticketutil/servicenow.py
+++ b/ticketutil/servicenow.py
@@ -475,7 +475,7 @@ def _prepare_ticket_fields(fields):
     :param fields: Ticket fields.
     :return: fields: Ticket fields for the ticketing tool.
     """
-    for key, value in fields.items():
+    for key, value in list(fields.items()):
         if key in ['opened_for', 'operating_system', 'category', 'item',
                    'severity', 'hostname_affected', 'opened_by_dept']:
             fields['u_{}'.format(key)] = value


### PR DESCRIPTION
`_prepare_ticket_fields` triggered a `RuntimeError: dictionary keys changed during iteration` exception in python 3.8. Converting the items() iterator to a list solves the problem.