### PR TITLE
Added new kwargs parameter to handle additional fields passed to reso…

### DIFF
--- a/read-the-docs/source/JIRA.rst
+++ b/read-the-docs/source/JIRA.rst
@@ -123,11 +123,19 @@ Adds a comment to a JIRA ticket.
 change_status()
 ---------------
 
+``change_status(self, status)``
 ``change_status(self, status, **kwargs)``
 
 Changes status of a JIRA ticket.
-With the future state of JIRA, no project will automatically set resolution when changing the status of the ticket to RESOLVED.
-We need to pass additional fields like 'resolution' or 'comment' to resolve the tickets via automation using TicketUtil itself.
+
+Some JIRA instances might not need extra parameters to change the status of the ticket. These instances will use the below code example.
+
+.. code:: python
+
+    t = ticket.change_status('In Progress')
+
+With the future state of JIRA, some JIRA instances may not automatically set resolution when changing the status of the ticket to RESOLVED.
+We need to pass additional fields like 'resolution' or 'comment' to resolve the tickets via automation using TicketUtil itself. See examples below.
 
 Parameters needed for the JIRA ticket to be Resolved from To Do/Groomed
 

--- a/read-the-docs/source/JIRA.rst
+++ b/read-the-docs/source/JIRA.rst
@@ -123,7 +123,6 @@ Adds a comment to a JIRA ticket.
 change_status()
 ---------------
 
-``change_status(self, status)``
 ``change_status(self, status, **kwargs)``
 
 Changes status of a JIRA ticket.
@@ -137,13 +136,13 @@ Some JIRA instances might not need extra parameters to change the status of the 
 With the future state of JIRA, some JIRA instances may not automatically set resolution when changing the status of the ticket to RESOLVED.
 We need to pass additional fields like 'resolution' or 'comment' to resolve the tickets via automation using TicketUtil itself. See examples below.
 
-Parameters needed for the JIRA ticket to be Resolved from To Do/Groomed
+Below code example to pass additional parameters like resolution and comment.
 
 .. code:: python
 
     t = ticket.change_status("Resolved", resolution="Rejected", comment="Resolved via automated process.")
 
-Parameters needed for the JIRA ticket to be Resolved from In Progress
+Below code example to pass only resolution parameter.
 
 .. code:: python
 

--- a/read-the-docs/source/JIRA.rst
+++ b/read-the-docs/source/JIRA.rst
@@ -123,13 +123,23 @@ Adds a comment to a JIRA ticket.
 change_status()
 ---------------
 
-``change_status(self, status)``
+``change_status(self, status, **kwargs)``
 
 Changes status of a JIRA ticket.
+With the future state of JIRA, no project will automatically set resolution when changing the status of the ticket to RESOLVED.
+We need to pass additional fields like 'resolution' or 'comment' to resolve the tickets via automation using TicketUtil itself.
+
+Parameters needed for the JIRA ticket to be Resolved from To Do/Groomed
 
 .. code:: python
 
-    t = ticket.change_status('In Progress')
+    t = ticket.change_status("Resolved", resolution="Rejected", comment="Resolved via automated process.")
+
+Parameters needed for the JIRA ticket to be Resolved from In Progress
+
+.. code:: python
+
+    t = ticket.change_status("Resolved", resolution="Fixed")
 
 remove_all_watchers()
 ---------------------

--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -315,11 +315,11 @@ class JiraTicket(ticket.Ticket):
         # Some of the ticket fields need to be in a specific form for the tool to be Resolved from In Progress/To Do/Groomed
         fields = _prepare_ticket_fields(kwargs)
 
-        # Parameters for the ticket to be Resolved from To Do/Groomed
+        # Below code is triggered if comment parameter is passed
         if 'comment' in kwargs:
             params['update'] = {'comment': [fields.pop('comment')]}
 
-        # Parameters for the ticket to be Resolved from In Progress
+        # Below code is triggered if resolution parameter is passed
         if 'resolution' in kwargs:
             params['fields'] = fields
 
@@ -332,7 +332,7 @@ class JiraTicket(ticket.Ticket):
             self.request_result = self.get_ticket_content()
             return self.request_result
         except requests.RequestException as e:
-            error_message = "Error changing status of ticket.If moving to a resolved state, try adding a resolution or comment."
+            error_message = "Error changing status of ticket. If moving to a resolved state, try adding a resolution or comment."
             logger.error(error_message)
             logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)

--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -314,15 +314,14 @@ class JiraTicket(ticket.Ticket):
 
         # Some of the ticket fields need to be in a specific form for the tool to be Resolved from In Progress/To Do/Groomed
         fields = _prepare_ticket_fields(kwargs)
-        if 'comment' in kwargs:
-            comment = fields.pop('comment')
 
-            # Parameters for the ticket to be Resolved from To Do/Groomed
-            params['update'] = {'comment': [comment]}
+        # Parameters for the ticket to be Resolved from To Do/Groomed
+        if 'comment' in kwargs:
+            params['update'] = {'comment': [fields.pop('comment')]}
 
         # Parameters for the ticket to be Resolved from In Progress
-        resolution = fields
-        params['fields'] = resolution
+        if 'resolution' in kwargs:
+            params['fields'] = fields
 
         # Attempt to change status of ticket
         try:
@@ -333,7 +332,7 @@ class JiraTicket(ticket.Ticket):
             self.request_result = self.get_ticket_content()
             return self.request_result
         except requests.RequestException as e:
-            error_message = "Error changing status of ticket"
+            error_message = "Error changing status of ticket.If moving to a resolved state, try adding a resolution or comment."
             logger.error(error_message)
             logger.error(e)
             return self.request_result._replace(status='Failure', error_message=error_message)


### PR DESCRIPTION
…lve the ticket status.

This commit satifies CONTENT-2123.

With the future state of JIRA no project will automatically set resolution when changing the status of the ticket to RESOLVED. RH support confirmed this when a support of the same was created. We will be handling the additional fields required to resolve the tickets via automation in TicketUtil itself.

Modified the change_status method by adding a kwargs parameter that will handle the additional fields required to either set the resolution or a add a comment while resolving a ticket or both so that JIRA tickets can be moved to RESOLVED state with TicketUtil automation.