### PR TITLE
Retry also HTTP POST requests [RHELDST-31841]

### DIFF
--- a/ticketutil/ticket.py
+++ b/ticketutil/ticket.py
@@ -104,7 +104,10 @@ class Ticket(object):
         # Set up authentication for requests session.
         s = requests.Session()
         retries = Retry(
-            total=8, backoff_factor=0.1, status_forcelist=[429, 500, 502, 503, 504]
+            total=8,
+            backoff_factor=0.1,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods={"GET", "POST", "OPTIONS", "DELETE", "TRACE", "PUT", "HEAD"},
         )
         adapter = HTTPAdapter(max_retries=retries)
         s.mount('http://', adapter)


### PR DESCRIPTION
The code already has retry logic that retries HTTP requests in case of server failures or when the client is rate-limited (HTTP error 429). However, by default, the retry logic only works for GET requests, not POST requests. This commit adds POST to the list of methods allowed to retry requests, in addition to the methods retried by the requests module.