### PR TITLE
Resolve client errors with Jira users and watchers

### DIFF
--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -27,6 +27,12 @@ MOCK_RESULT = {'errorMessages': ["No project could be found with key \'{0}\'.".f
 TICKET_CONTENT = {'key': 'TICKET_ID', 'errors': {'ResponseError': 'No internet connection'}}
 STATUS = {'transitions': [{'to': {'name': 'To Do'}, 'id': 11}, {'to': {'name': 'Abandoned'}, 'id': 51}]}
 WATCHERS = {'watchers': [{'name': 'me'}, {'name': 'you'}]}
+WATCHERS_CLOUD = {'watchers': [{'accountId': 'me123'}, {'accountId': 'you123'}]}
+SERVER_INFO = {'cloud':{'deploymentType': 'Cloud'},
+               'server':{'deploymentType': 'Server'},
+               'unknown':{}}
+USER_SEARCH_CLOUD = [{'self': '{0}/rest/api/2/user?accountId=me123'.format(URL)}]
+USER_SEARCH_SERVER = [{'self': '{0}/rest/api/2/user?username=me'.format(URL)}]
 
 
 class FakeSession(object):
@@ -34,14 +40,19 @@ class FakeSession(object):
     Mocks Requests session behavior.
     """
 
-    def __init__(self, status_code=666):
+    def __init__(self, status_code=666, cloud=None):
         self.status_code = status_code
+        self.cloud = cloud
 
     def get(self, url):
+        if 'serverInfo' in url:
+            return FakeResponseServerInfo(status_code=self.status_code, cloud=self.cloud)
         if 'transitions' in url:
             return FakeResponseGetStatus(status_code=self.status_code)
         elif 'watchers' in url:
-            return FakeResponseGetWatchers(status_code=self.status_code)
+            return FakeResponseGetWatchers(status_code=self.status_code, cloud=self.cloud)
+        elif 'user' in url and 'search' in url:
+            return FakeResponseUserSearch(status_code=self.status_code, url=url)
         else:
             return FakeResponse(status_code=self.status_code)
 
@@ -106,8 +117,44 @@ class FakeResponseGetWatchers(FakeResponse):
     Response when trying to get a list of watchers.
     """
 
+    def __init__(self, status_code=666, cloud=False):
+        super(FakeResponseGetWatchers, self).__init__(status_code)
+        self.cloud = cloud
+
     def json(self):
-        return WATCHERS
+        return WATCHERS_CLOUD if self.cloud else WATCHERS
+
+
+class FakeResponseServerInfo(FakeResponse):
+    """
+    Response when trying to get serverInfo for deployment type.
+    """
+
+    def __init__(self, status_code=666, cloud=None):
+        super(FakeResponseServerInfo, self).__init__(status_code)
+        self.cloud = cloud
+
+    def json(self):
+        if self.cloud is True:
+            return SERVER_INFO['cloud']
+        elif self.cloud is False:
+            return SERVER_INFO['server']
+        return SERVER_INFO['unknown']
+
+
+class FakeResponseUserSearch(FakeResponse):
+    """
+    Response when trying to search users using query or username.
+    """
+
+    def __init__(self, status_code=666, url=''):
+        super(FakeResponseUserSearch, self).__init__(status_code)
+        self._url = url
+
+    def json(self):
+        if 'query=' in self._url:
+            return USER_SEARCH_CLOUD
+        return USER_SEARCH_SERVER
 
 
 class TestJiraTicket(TestCase):
@@ -146,6 +193,22 @@ class TestJiraTicket(TestCase):
         with self.assertRaises(TicketException):
             ticket = jira.JiraTicket(URL, PROJECT)
             self.assertFalse(ticket._verify_project(PROJECT))
+
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_is_cloud_deployment(self, mock_session):
+        mock_session.return_value = FakeSession(cloud=True)
+        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
+        self.assertTrue(ticket.is_cloud)
+        self.assertEqual(ticket._watcher_query_param, 'accountId')
+        self.assertEqual(ticket._get_watchers_list(), ['me123', 'you123'])
+
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_is_not_cloud_deployment(self, mock_session):
+        mock_session.return_value = FakeSession(cloud=False)
+        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
+        self.assertFalse(ticket.is_cloud)
+        self.assertEqual(ticket._watcher_query_param, 'username')
+        self.assertEqual(ticket._get_watchers_list(), ['me', 'you'])
 
     @patch.object(jira.JiraTicket, '_create_requests_session')
     def test_get_ticket_content(self, mock_session):
@@ -318,6 +381,18 @@ class TestJiraTicket(TestCase):
         request_result = ticket.remove_all_watchers()
         self.assertEqual(request_result, SUCCESS_RESULT._replace(watchers=watchers))
 
+    @patch.object(jira.JiraTicket, 'get_ticket_content')
+    @patch.object(jira.JiraTicket, '_get_watchers_list')
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_remove_all_watchers_cloud(self, mock_session, mock_get_list, mock_content):
+        mock_session.return_value = FakeSession(cloud=True)
+        mock_content.return_value = SUCCESS_RESULT
+        watchers = ['me123', 'you123']
+        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
+        mock_get_list.return_value = watchers
+        request_result = ticket.remove_all_watchers()
+        self.assertEqual(request_result, SUCCESS_RESULT._replace(watchers=watchers))
+
     @patch.object(jira.JiraTicket, '_create_requests_session')
     def test_remove_all_watchers_no_ticket_id(self, mock_session):
         mock_session.return_value = FakeSession()
@@ -344,6 +419,14 @@ class TestJiraTicket(TestCase):
     @patch.object(jira.JiraTicket, '_create_requests_session')
     def test_remove_watcher(self, mock_session, mock_url, mock_content):
         mock_session.return_value = FakeSession()
+        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
+        request_result = ticket.remove_watcher('me')
+        self.assertEqual(request_result, mock_content.return_value)
+
+    @patch.object(jira.JiraTicket, 'get_ticket_content')
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_remove_watcher_cloud(self, mock_session, mock_content):
+        mock_session.return_value = FakeSession(cloud=True)
         ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
         request_result = ticket.remove_watcher('me')
         self.assertEqual(request_result, mock_content.return_value)
@@ -376,6 +459,14 @@ class TestJiraTicket(TestCase):
         request_result = ticket.add_watcher('me')
         self.assertEqual(request_result, mock_content.return_value)
 
+    @patch.object(jira.JiraTicket, 'get_ticket_content')
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_add_watcher_cloud(self, mock_session, mock_content):
+        mock_session.return_value = FakeSession(cloud=True)
+        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
+        request_result = ticket.add_watcher('me')
+        self.assertEqual(request_result, mock_content.return_value)
+
     @patch.object(jira.JiraTicket, '_create_requests_session')
     def test_add_watcher_no_ticket_id(self, mock_session):
         mock_session.return_value = FakeSession()
@@ -404,6 +495,24 @@ class TestJiraTicket(TestCase):
         error_message = 'Error adding  as a watcher to ticket'
         self.assertEqual(request_result, RETURN_RESULT('Failure', error_message, mock_url.return_value, MOCK_RESULT,
                                                        None))
+
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_get_user_id(self, mock_session):
+        mock_session.return_value = FakeSession()
+        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
+        self.assertEqual(ticket._get_user_id('me'), 'me')
+        self.assertEqual(ticket._get_user_id('me@example.com'), 'me')
+        self.assertIsNone(ticket._get_user_id(''))
+        self.assertIsNone(ticket._get_user_id(None))
+
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_get_user_id_cloud(self, mock_session):
+        mock_session.return_value = FakeSession(cloud=True)
+        ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)
+        self.assertEqual(ticket._get_user_id('me'), 'me123')
+        self.assertEqual(ticket._get_user_id('me@example.com'), 'me123')
+        self.assertIsNone(ticket._get_user_id(''))
+        self.assertIsNone(ticket._get_user_id(None))
 
     @patch.object(jira.JiraTicket, 'get_ticket_content')
     @patch('builtins.open')

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -47,7 +47,7 @@ class FakeSession(object):
     def get(self, url):
         if 'serverInfo' in url:
             return FakeResponseServerInfo(status_code=self.status_code, cloud=self.cloud)
-        if 'transitions' in url:
+        elif 'transitions' in url:
             return FakeResponseGetStatus(status_code=self.status_code)
         elif 'watchers' in url:
             return FakeResponseGetWatchers(status_code=self.status_code, cloud=self.cloud)

--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -590,13 +590,14 @@ class JiraTicket(ticket.Ticket):
             # https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/#api/2/user-findUsers
             user_details = r.json()
             if user_details:
-                username = user_details[0]['self'].split("=")[1].strip()
+                # user_id is an accountId if deploymentType is cloud, a username if not
+                user_id = user_details[0]['self'].split("=")[1].strip()
             else:
-                username = None
+                user_id = None
                 # workaround to handle "User not found issue" when JIRA API does not return expected error code
                 logger.error("User {0} could not be found".format(user))
 
-            return username
+            return user_id
         except requests.RequestException as e:
             if (
                 'application/json' in r.headers['content-type']

--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -24,7 +24,7 @@ class JiraTicket(ticket.Ticket):
         # HTTP Basic Auth
         if isinstance(auth, tuple):
             self.auth = auth
-            self.auth_url = self.url
+            self.auth_url = "{0}/rest/api/2/myself".format(self.url)
         # Personal Access Token Auth
         elif isinstance(auth, dict):
             if 'token' in auth:
@@ -49,6 +49,9 @@ class JiraTicket(ticket.Ticket):
         # Call our parent class's init method which creates our requests session.
         super(JiraTicket, self).__init__(project, ticket_id, verify=verify)
 
+        self.is_cloud = self._detect_jira_cloud()
+        self._watcher_query_param = 'accountId' if self.is_cloud else 'username'
+
         # Overwrite our request_result namedtuple from Ticket, adding watchers field for JiraTicket.
         Result = namedtuple('Result', ['status', 'error_message', 'url', 'ticket_content', 'watchers'])
         self.request_result = Result('Success', None, self.ticket_url, self.ticket_content, None)
@@ -69,6 +72,21 @@ class JiraTicket(ticket.Ticket):
         self.request_result = self.request_result._replace(url=ticket_url)
 
         return ticket_url
+
+    def _detect_jira_cloud(self):
+        """
+        Queries the JIRA API to determine whether the Atlassian instance is Cloud.
+        :return: True if the Atlassian instance is Cloud, False otherwise.
+        """
+        try:
+            r = self.s.get("{0}/rest/api/2/serverInfo".format(self.url))
+            logger.debug("Detect Jira Cloud: status code: {0}".format(r.status_code))
+            r.raise_for_status()
+            return r.json().get('deploymentType') == 'Cloud'
+        except requests.RequestException as e:
+            logger.error("Unable to determine Jira deployment type from serverInfo; assuming non-cloud.")
+            logger.error(e)
+            return False
 
     def _verify_project(self, project):
         """
@@ -379,7 +397,7 @@ class JiraTicket(ticket.Ticket):
         watchers_list = self._get_watchers_list()
         for watcher in watchers_list:
             try:
-                r = self.s.delete("{0}/{1}/watchers?username={2}".format(self.rest_url, self.ticket_id, watcher))
+                r = self.s.delete("{0}/{1}/watchers?{2}={3}".format(self.rest_url, self.ticket_id, self._watcher_query_param, watcher))
                 logger.debug("Remove watcher {0}: status code: {1}".format(watcher, r.status_code))
                 r.raise_for_status()
             except requests.RequestException as e:
@@ -409,19 +427,19 @@ class JiraTicket(ticket.Ticket):
             logger.error(error_message)
             return self.request_result._replace(status='Failure', error_message=error_message)
 
-        # If an email address was passed in for watcher param, call the _get_username_from_email method to get
-        # username for watcher .
-        if '@' in watcher:
-            watcher_username = self._get_username_from_email(watcher)
-        else:
-            watcher_username = watcher
+        watcher_id = self._get_user_id(watcher)
+
+        if watcher_id is None:
+            error_message = "Error removing watcher {0} from ticket".format(watcher)
+            logger.error(error_message)
+            return self.request_result._replace(status='Failure', error_message=error_message)
 
         try:
-            r = self.s.delete("{0}/{1}/watchers?username={2}".format(self.rest_url, self.ticket_id, watcher_username))
-            logger.debug("Remove watcher {0}: status code: {1}".format(watcher_username, r.status_code))
+            r = self.s.delete("{0}/{1}/watchers?{2}={3}".format(self.rest_url, self.ticket_id, self._watcher_query_param, watcher_id))
+            logger.debug("Remove watcher {0}: status code: {1}".format(watcher_id, r.status_code))
             r.raise_for_status()
             logger.info(
-                "Removed watcher {0} from ticket {1} - {2}".format(watcher_username, self.ticket_id, self.ticket_url))
+                "Removed watcher {0} from ticket {1} - {2}".format(watcher_id, self.ticket_id, self.ticket_url))
             self.request_result = self.get_ticket_content()
             return self.request_result
         except requests.RequestException as e:
@@ -434,7 +452,7 @@ class JiraTicket(ticket.Ticket):
         """
         Adds watcher to a JIRA ticket.
         Accepts an email or username.
-        :param watcher: Username of watcher to remove.
+        :param watcher: Username of watcher to add.
         :return: self.request_result: Named tuple containing request status, error_message, url info and
                  ticket_content.
         """
@@ -443,23 +461,21 @@ class JiraTicket(ticket.Ticket):
             logger.error(error_message)
             return self.request_result._replace(status='Failure', error_message=error_message)
 
-        # If an email address was passed in for watcher param, call the _get_username_from_email method to get
-        # username for watcher .
-        if '@' in watcher:
-            watcher_username = self._get_username_from_email(watcher)
-        else:
-            watcher_username = watcher
+        watcher_id = self._get_user_id(watcher)
 
         # For some reason, if you try to add an empty string as a watcher, it adds the requestor.
         # So, only execute this code if the watcher is not an empty string.
-        if watcher_username:
-            watcher_username = "\"{0}\"".format(watcher_username)
+        if watcher_id:
             try:
-                r = self.s.post("{0}/{1}/watchers".format(self.rest_url, self.ticket_id), data=watcher_username)
-                logger.debug("Add watcher {0}: status code: {1}".format(watcher_username, r.status_code))
+                if self.is_cloud:
+                    r = self.s.post("{0}/{1}/watchers".format(self.rest_url, self.ticket_id), json=watcher_id)
+                else:
+                    watcher_id = "\"{0}\"".format(watcher_id)
+                    r = self.s.post("{0}/{1}/watchers".format(self.rest_url, self.ticket_id), data=watcher_id)
+                logger.debug("Add watcher {0}: status code: {1}".format(watcher_id, r.status_code))
                 r.raise_for_status()
                 logger.info(
-                    "Added watcher {0} to ticket {1} - {2}".format(watcher_username, self.ticket_id, self.ticket_url))
+                    "Added watcher {0} to ticket {1} - {2}".format(watcher_id, self.ticket_id, self.ticket_url))
                 self.request_result = self.get_ticket_content()
                 return self.request_result
             except requests.RequestException as e:
@@ -544,20 +560,30 @@ class JiraTicket(ticket.Ticket):
 
         watchers_json = r.json()
         watchers_list = []
+        key = 'accountId' if self.is_cloud else 'name'
         for watcher in watchers_json['watchers']:
-            watchers_list.append(watcher['name'])
+            watchers_list.append(watcher[key])
 
         return watchers_list
 
-    def _get_username_from_email(self, email):
+    def _get_user_id(self, user):
         """
-        Gets the username from JIRA account
-        :param email: takes email id of user as an argument
-        :return: username
+        Gets the username or accountId from JIRA account.
+        :param user: takes username or email id of user as an argument.
+        :return: username or accountId, depending on the JIRA deployment type.
         """
+        # Return None if the user parameter is empty.
+        if not user:
+            return None
+        
+        # If the deployment type is not cloud and the user parameter is not an email, return the username.
+        if not self.is_cloud and '@' not in user:
+            return user
+
         rest_url_user = '{0}/rest/api/2/user'.format(self.url)
         try:
-            r = self.s.get("{0}/search?username={1}".format(rest_url_user, email))
+            user_query_param = 'query' if self.is_cloud else 'username'
+            r = self.s.get("{0}/search?{1}={2}".format(rest_url_user, user_query_param, user))
             logger.debug("Search username: status code: {0}".format(r.status_code))
             r.raise_for_status()  # currently if the requested user is not found then
             # instead of 404 API returns 200 status code and [] empty response. Reference -
@@ -568,7 +594,7 @@ class JiraTicket(ticket.Ticket):
             else:
                 username = None
                 # workaround to handle "User not found issue" when JIRA API does not return expected error code
-                logger.error("User with email {0} could not be found".format(email))
+                logger.error("User {0} could not be found".format(user))
 
             return username
         except requests.RequestException as e:
@@ -576,7 +602,7 @@ class JiraTicket(ticket.Ticket):
                 'application/json' in r.headers['content-type']
                 and "User does not exist" in r.json()['errorMessages'][0].lower()
             ):
-                error_message = "User {0} is not valid".format(email)
+                error_message = "User {0} is not valid".format(user)
                 logger.error(error_message)
             else:
                 error_message = "Error getting user details"


### PR DESCRIPTION
Related Jira issue with context: https://redhat.atlassian.net/browse/CONTENT-4010

Essentially, Jira Cloud API has deprecated and removed `username`/`name` from users in favor of `accountId`. Since Atlassian migration, this has affected CAT. This requires changes to 

1. pulling user information 
        - not queryable by `username` param anymore, but via a `query` param which can search for user by username or email
2. adding and removing watchers to issues by their `accountId` instead 

This [migration guide](https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/) might help provide more context.

This commit satisfies CONTENT-4010.