### PR TITLE
Implements api token authentication support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,8 @@ various ticketing tools using their REST APIs. Currently, the supported
 tools are JIRA, RT, Redmine, Bugzilla, and ServiceNow. All tools support
 HTTP Basic authentication, while JIRA and RT also support Kerberos
 authentication. Additionally, Bugzilla supports API key authentication and
-Jira supports Personal Access Token authentication.
+Jira supports API Token authentication (for Jira Cloud) and Personal Access
+Token authentication.
 
 This module allows you to create tickets, add comments, edit ticket
 fields, and change the status of tickets in each tool. Additional

--- a/read-the-docs/source/JIRA.rst
+++ b/read-the-docs/source/JIRA.rst
@@ -228,6 +228,19 @@ https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032
                             <project_key>,
                             auth={'token': <your_token>})
 
+Authenticate with Jira Cloud API Token.
+API tokens can be generated at: <jira-domain>/manage-profile/security/api-tokens
+
+See the following URL for details:
+https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/
+
+.. code:: python
+
+    >>> from ticketutil.jira import JiraTicket
+    >>> ticket = JiraTicket(<jira_url>,
+                            <project_key>,
+                            auth={'username': <email_or_username>, 'api_token': <your_api_token>})
+
 Use proxy to access Jira. See the following URL for details on configuring
 proxy with requests library:
 https://docs.python-requests.org/en/latest/user/advanced/#proxies

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -168,6 +168,21 @@ class TestJiraTicket(TestCase):
     """
 
     @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_api_token_auth(self, mock_session):
+        mock_session.return_value = FakeSession()
+        auth = {'username': 'user@example.com', 'api_token': 'test_api_token'}
+        ticket = jira.JiraTicket(URL, PROJECT, auth=auth)
+        self.assertEqual(ticket.auth, ('user@example.com', 'test_api_token'))
+        self.assertEqual(ticket.auth_url, URL)
+
+    @patch.object(jira.JiraTicket, '_create_requests_session')
+    def test_api_token_auth_missing_username(self, mock_session):
+        mock_session.return_value = FakeSession()
+        auth = {'api_token': 'test_api_token'}
+        with self.assertRaises(KeyError) as context:
+            jira.JiraTicket(URL, PROJECT, auth=auth)
+
+    @patch.object(jira.JiraTicket, '_create_requests_session')
     def test_generate_ticket_url(self, mock_session):
         mock_session.return_value = FakeSession()
         ticket = jira.JiraTicket(URL, PROJECT, ticket_id=TICKET_ID)

--- a/ticketutil/jira.py
+++ b/ticketutil/jira.py
@@ -25,14 +25,19 @@ class JiraTicket(ticket.Ticket):
         if isinstance(auth, tuple):
             self.auth = auth
             self.auth_url = "{0}/rest/api/2/myself".format(self.url)
-        # Personal Access Token Auth
+        # API Token or Personal Access Token Auth
         elif isinstance(auth, dict):
-            if 'token' in auth:
+            if 'api_token' in auth:
+                if 'username' not in auth:
+                    raise KeyError("username is required when using api_token authentication")
+                self.auth = (auth['username'], auth['api_token'])
+                self.auth_url = "{0}/rest/api/2/myself".format(self.url)
+            elif 'token' in auth:
                 self.auth = auth
                 self.auth_url = "{0}/rest/api/2/myself".format(self.url)
                 self.headers = {"Authorization": "Bearer {0}".format(auth['token'])}
             else:
-                raise KeyError("token is a required auth key for personal access token authentication")
+                raise KeyError("Either api_token (with username) or token is a required auth key for authentication")
         # Kerberos Auth
         else:
             self.auth = 'kerberos'


### PR DESCRIPTION
Currently, Cloud Jira doesn't support Personal Access Token but API tokens are supported. This commit adds support of api tokens as authentication way.